### PR TITLE
Mitra/ Fix test failure as etf is available in eu

### DIFF
--- a/cypress/e2e/smoke/home1.cy.js
+++ b/cypress/e2e/smoke/home1.cy.js
@@ -80,7 +80,8 @@ describe('QATEST-1279 - Navigation Responsive - Menu items - EU and ROW (Includi
 
       cy.findByRole('img', { name: 'hamburger menu' }).click()
       cy.findByRole('button', { name: 'Markets chevron' }).click({force: true})
-      cy.findByRole('link', { name: 'Exchange-traded funds (ETFs) Exchange-traded funds (ETFs) Diversify your portfolio and enjoy low-cost intraday trading with ETFs.' }).should('not.exist')
+      cy.findByRole('link', { name: 'Exchange-traded funds (ETFs) Exchange-traded funds (ETFs) Diversify your portfolio and enjoy low-cost intraday trading with ETFs.' }).click()
+      cy.findByRole('heading', { name: 'Exchange-traded funds' }).should('be.visible')
 
       cy.findByRole('img', { name: 'close menu' }).click()
 


### PR DESCRIPTION
We made ETF available for the EU region in deriv.com so the test case for the navigation to not show ETF to EU was failing which is fixed in this pr
<img width="1156" alt="Screenshot 2023-10-25 at 11 49 40 PM" src="https://github.com/deriv-com/e2e-deriv-com/assets/64970259/a22d4707-b77c-4e93-b256-0a04abe3e26f">

<img width="771" alt="Screenshot 2023-10-26 at 12 00 19 AM" src="https://github.com/deriv-com/e2e-deriv-com/assets/64970259/399aa1f6-f7a1-43e3-9171-7ad9580b499b">
