### PR TITLE
tradenowtestcasefix

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -33,6 +33,9 @@ module.exports = defineConfig({
     youtubeEU: 'https://www.youtube.com/@deriv',
     linkedInEU: 'https://www.linkedin.com/company/derivdotcom/',
     derivlifeURL: 'https://derivlife.com/',
-    derivBlogURL: 'https://blog.deriv.com/'
-  },
+    derivBlogURL: 'https://blog.deriv.com/',
+    loginURL: 'https://oauth.deriv.com',
+    stagingderivURL: 'https://staging.deriv.com/',
+    derivURL: 'https://deriv.com/'
+  }
 })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -257,12 +257,13 @@ Cypress.Commands.add('commodities_viewall', (site, view) => {
 })
 
 Cypress.Commands.add('check_tradingspecs_and_tradenow_button', () => {
+  const externalEUUrls = Cypress.config('externalEUUrls')
   cy.findByRole('link', { name: 'Check trading specs' }).click()
   cy.url().should('include', 'trading-specification')
   cy.findByText('Trading specifications for CFDs on Deriv').should('be.visible')
   cy.go(-1)
   cy.url().then((url) => {
-     if (url.includes('staging.deriv') || url.includes('deriv.com')) 
+     if (url.includes(externalEUUrls.stagingderivURL) || url.includes(externalEUUrls.derivURL)) 
      {
        cy.findByRole('button', { name: 'Trade now' }).click()
        cy.get('.title-text').contains('Welcome!').should('be.visible');
@@ -270,7 +271,7 @@ Cypress.Commands.add('check_tradingspecs_and_tradenow_button', () => {
      else 
      {
        cy.findByRole('button', { name: 'Trade now' }).click()
-       cy.origin('https://oauth.deriv.com', () => {
+       cy.origin(externalEUUrls.loginURL, () => {
        cy.get('.title-text').contains('Welcome!').should('be.visible');
        })
      }

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -261,6 +261,20 @@ Cypress.Commands.add('check_tradingspecs_and_tradenow_button', () => {
   cy.url().should('include', 'trading-specification')
   cy.findByText('Trading specifications for CFDs on Deriv').should('be.visible')
   cy.go(-1)
-  cy.findByRole('button', { name: 'Trade now' }).click()
-  cy.get('.title-text').contains('Welcome!').should('be.visible')
-})
+  cy.url().then((url) => {
+     if (url.includes('staging.deriv') || url.includes('deriv.com')) 
+     {
+       cy.findByRole('button', { name: 'Trade now' }).click()
+       cy.get('.title-text').contains('Welcome!').should('be.visible');
+     } 
+     else 
+     {
+       cy.findByRole('button', { name: 'Trade now' }).click()
+       cy.origin('https://oauth.deriv.com', () => {
+       cy.get('.title-text').contains('Welcome!').should('be.visible');
+       })
+     }
+   })
+ })
+
+  


### PR DESCRIPTION
This PR has a fix for issue when "Trade Now" button from homepage is clicked it navigates to oauth.deriv.com , but when navigated to oauth.deriv.com from **testlink** there is a domain change due to which the script failed  . With cy.origin() we can execute commands against multi-domain  . 
So if the test execution is for testlink , then using cy.origin -> cypress executes the test runtime into the secondary origin , executes that function in the secondary domain, and finally returns control to the original test origin. 
Else if test execution is for staging.deriv.com or deriv.com , then navigating to oauth.deriv.com is not an issue as it is of the same domain . cy.origin() is not required here .
