### PR TITLE
added robots txt test

### DIFF
--- a/cypress/e2e/full/allRobotsTxt.cy.js
+++ b/cypress/e2e/full/allRobotsTxt.cy.js
@@ -1,0 +1,26 @@
+import '@testing-library/cypress/add-commands'
+
+describe('QATEST-42045 - Check Robots Txt Content', () => {
+  it('visits the robots.txt file and verifies content', () => {
+    cy.request(Cypress.config('baseUrl') + '/robots.txt').then((response) => {
+      expect(response.status).to.eq(200)
+
+      const robotsTxtContent = response.body
+
+      expect(robotsTxtContent).to.include('User-agent: *')
+      expect(robotsTxtContent).to.include('Allow: /')
+      expect(robotsTxtContent).to.include('Disallow: /404/')
+      expect(robotsTxtContent).to.include('Disallow: /homepage/')
+      expect(robotsTxtContent).to.include('Disallow: /landing/')
+      expect(robotsTxtContent).to.include('Disallow: /endpoint/')
+      expect(robotsTxtContent).to.include('Disallow: /livechat/')
+      expect(robotsTxtContent).to.include('Disallow: /storybook/')
+      expect(robotsTxtContent).to.include('Disallow: *.binary.sx')
+      expect(robotsTxtContent).to.include('Disallow: /?region=*/')
+      expect(robotsTxtContent).to.include(
+        'Sitemap: https://deriv.com/sitemap-index.xml'
+      )
+      expect(robotsTxtContent).to.include('Host: https://deriv.com')
+    })
+  })
+})

--- a/cypress/e2e/full/allRobotsTxt.cy.js
+++ b/cypress/e2e/full/allRobotsTxt.cy.js
@@ -2,7 +2,7 @@ import '@testing-library/cypress/add-commands'
 
 describe('QATEST-42045 - Check Robots Txt Content', () => {
   it('visits the robots.txt file and verifies content', () => {
-    cy.request(Cypress.config('baseUrl') + '/robots.txt').then((response) => {
+    cy.request('/robots.txt').then((response) => {
       expect(response.status).to.eq(200)
 
       const robotsTxtContent = response.body


### PR DESCRIPTION
This is one of the tasks to migrate the important test from RobotFramework to Cypress. The `../robots.txt` is make sure we did not break the SEO.

Local test result:
<img width="489" alt="image" src="https://github.com/deriv-com/e2e-deriv-com/assets/31909236/f89576a5-b2e8-4c73-9214-8e5218df7e04">

Clickup task: https://app.clickup.com/t/20696747/DERC-2256