### PR TITLE
add daily cron

### DIFF
--- a/.github/workflows/cypress_cloud_cron.yml
+++ b/.github/workflows/cypress_cloud_cron.yml
@@ -1,0 +1,46 @@
+name: Daily Cron for Smoke Tests
+
+on:
+  schedule:
+    - cron: '0 0 * * 1-5' # Runs every day (Monday to Friday) at 0:00 GMT
+
+jobs:
+  cypress-run:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false # https://github.com/cypress-io/github-action/issues/48
+      matrix:
+        containers: [1,2,3] # Uses 3 instance
+
+    steps:
+    - name: Checkout external repository with Cypress tests
+      uses: actions/checkout@v4
+      with:
+        repository: deriv-com/e2e-deriv-com # Replace with your repository name
+
+    - name: Cypress run
+      # Uses the official Cypress GitHub action https://github.com/cypress-io/github-action
+      uses: cypress-io/github-action@v6
+      with:
+        # Starts web server for E2E tests - replace with your own server invocation
+        # https://docs.cypress.io/guides/continuous-integration/introduction#Boot-your-server
+        # start: npm start
+        # wait-on: 'http://localhost:3000' # Waits for above
+        # Records to Cypress Cloud 
+        # https://docs.cypress.io/guides/cloud/projects#Set-up-a-project-to-record
+        record: true
+        parallel: true # Runs test in parallel using settings above
+        spec: cypress/e2e/smoke/*.js
+        group: 'e2e Tests'
+        
+      env:
+        # For recording and parallelization to work you must set your CYPRESS_RECORD_KEY
+        # in GitHub repo → Settings → Secrets → Actions
+        CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+        # Creating a token https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
+        # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Set Base Url from client_payload.
+        CYPRESS_BASE_URL: "https://staging.deriv.com/"
+        # Send PR details to Cypress test run
+        COMMIT_INFO_MESSAGE: Daily cron for smoke tests on https://staging.deriv.com/
+          


### PR DESCRIPTION
This PR is to include a daily cron job that executes smoke tests on the staging environment on weekdays at 0:00 GMT. The test result will act as the primary indicator for the smoke test status.
 
CU task: https://app.clickup.com/t/20696747/DERC-2396