### PR TITLE
Ako/ use commit hash for cypress github action

### DIFF
--- a/.github/workflows/cypress_cloud.yml
+++ b/.github/workflows/cypress_cloud.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Cypress run
         # Uses the official Cypress GitHub action https://github.com/cypress-io/github-action
-        uses: cypress-io/github-action@v6
+        uses: cypress-io/github-action@1b70233146622b69e789ccdd4f9452adc638d25a
         with:
           # Starts web server for E2E tests - replace with your own server invocation
           # https://docs.cypress.io/guides/continuous-integration/introduction#Boot-your-server

--- a/.github/workflows/cypress_cloud_cron.yml
+++ b/.github/workflows/cypress_cloud_cron.yml
@@ -20,7 +20,7 @@ jobs:
 
     - name: Cypress run
       # Uses the official Cypress GitHub action https://github.com/cypress-io/github-action
-      uses: cypress-io/github-action@v6
+      uses: cypress-io/github-action@1b70233146622b69e789ccdd4f9452adc638d25a
       with:
         # Starts web server for E2E tests - replace with your own server invocation
         # https://docs.cypress.io/guides/continuous-integration/introduction#Boot-your-server

--- a/.github/workflows/cypress_cloud_manual.yml
+++ b/.github/workflows/cypress_cloud_manual.yml
@@ -31,7 +31,7 @@ jobs:
 
     - name: Cypress run
       # Uses the official Cypress GitHub action https://github.com/cypress-io/github-action
-      uses: cypress-io/github-action@v6
+      uses: cypress-io/github-action@1b70233146622b69e789ccdd4f9452adc638d25a
       with:
         # Starts web server for E2E tests - replace with your own server invocation
         # https://docs.cypress.io/guides/continuous-integration/introduction#Boot-your-server

--- a/.github/workflows/cypress_cloud_withtoken.yml
+++ b/.github/workflows/cypress_cloud_withtoken.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Cypress run
         # Uses the official Cypress GitHub action https://github.com/cypress-io/github-action
-        uses: cypress-io/github-action@v6
+        uses: cypress-io/github-action@1b70233146622b69e789ccdd4f9452adc638d25a
         with:
           # Starts web server for E2E tests - replace with your own server invocation
           # https://docs.cypress.io/guides/continuous-integration/introduction#Boot-your-server


### PR DESCRIPTION
this is to use commit sha instead of version for action `cypress-io/github-action` to reduce the security vulnerability of it.