### PR TITLE
Bilal/derc 2460 fix cypress full test master failures

### DIFF
--- a/.github/workflows/cypress_cloud_manual.yml
+++ b/.github/workflows/cypress_cloud_manual.yml
@@ -44,7 +44,7 @@ jobs:
         # https://docs.cypress.io/guides/cloud/projects#Set-up-a-project-to-record
         record: true
         parallel: true # Runs test in parallel using settings above
-        spec: cypress/e2e/${{ github.event.inputs.suite }}/tradingPlatformDbot.cy.js
+        spec: cypress/e2e/${{ github.event.inputs.suite }}/*.js
         group: 'e2e Tests'
       env:
         # For recording and parallelization to work you must set your CYPRESS_RECORD_KEY

--- a/.github/workflows/cypress_cloud_manual.yml
+++ b/.github/workflows/cypress_cloud_manual.yml
@@ -44,7 +44,7 @@ jobs:
         # https://docs.cypress.io/guides/cloud/projects#Set-up-a-project-to-record
         record: true
         parallel: true # Runs test in parallel using settings above
-        spec: cypress/e2e/${{ github.event.inputs.suite }}/*.js
+        spec: cypress/e2e/${{ github.event.inputs.suite }}/tradingPlatformDbot.cy.js
         group: 'e2e Tests'
       env:
         # For recording and parallelization to work you must set your CYPRESS_RECORD_KEY

--- a/cypress/e2e/full/checkAllLanguages.cy.js
+++ b/cypress/e2e/full/checkAllLanguages.cy.js
@@ -166,7 +166,7 @@ describe(`QATEST-101611 - Url redirection for all languages`, () => {
     })
     Object.entries(languageDetails).forEach((lang) => {
         screenSizes.forEach(screenSize=>{
-            it.only(`should verify language redrection for ${lang[1].testLanguage} via link for ${screenSize} size`, () => {
+            it(`should verify language redrection for ${lang[1].testLanguage} via link for ${screenSize} size`, () => {
                 redirectionRules.forEach(rule => {
                     cy.c_visitResponsive(`/${lang[1].urlCode}${rule}`,screenSize)
                     cy.get('[id="cta-container"]').within(() => {

--- a/cypress/e2e/full/tradingPlatformCtrader.cy.js
+++ b/cypress/e2e/full/tradingPlatformCtrader.cy.js
@@ -63,7 +63,7 @@ describe('QATEST-23425 - should validate the cTrader page in desktop', () => {
     it('should be able to navigate to cTrader page from home page and validate the page content and links in Desktop', () => {
         cy.c_visitResponsive(Cypress.env('RegionROW'), 'desktop')
         homeBanner.elements.tradeMenu().should('be.visible').click()
-        cy.findByText('Fast CFDs platform with inbuilt copy trading.').should('be.visible').click()
+        cy.findAllByText('Fast CFDs platform with inbuilt copy trading.').eq(0).should('be.visible').click()
         cTrader_page()
     })    
 })

--- a/cypress/e2e/full/tradingPlatformCtrader.cy.js
+++ b/cypress/e2e/full/tradingPlatformCtrader.cy.js
@@ -17,17 +17,35 @@ function cTrader_page() {
      Verify('Demo account', 'Demo')
      Verify('Real account', 'Real')
 
-    cy.findByRole('heading', { name: 'Check out our other platforms' }).should('be.visible')
-    for (let index = 0; index < 4; index++) 
-    {
-        cy.findAllByText('Learn more' , {timeout: 10000}).eq(index).click()
-        const urlPath = ['/dmt5/', '/dtrader/', '/deriv-go/', '/derivx/', '/dbot/'];
+     const urlDetails = [
+        {
+            url:'/dmt5/',
+            title:'Deriv MT5 | MetaTrader 5 trading platform | Deriv',
+            content:'Get trading with Deriv MT5',
+        }, 
+        {
+            url:'/dtrader/',
+            title:'DTrader | Online trading platform | Deriv',
+            content:'Get into the Deriv Trader experience',
+        }, 
+        {
+            url:'/deriv-go/',
+            title:'Trade forex, synthetics, and cryptocurrencies with our app — Deriv GO.',
+            content:'Get trading with Deriv GO',
+        }, 
+        {
+            url:'/derivx/', 
+            title:'Deriv X - a multi-asset CFD trading platform available on Deriv',
+            content:'Get trading with Deriv X'
+        },
+        {
+            url:'/dbot/',
+            title:'DBot | Trading robot | Deriv',
+            content:'Get into the Deriv Bot experience',
+        }, 
+    ]
 
-        cy.url().should(url => {
-        expect(urlPath.some(path => url.includes(path))).to.be.true;
-        });
-        cy.c_go('back'); 
-    }
+    cy.c_checkAllPlatformLinks(urlDetails)
 
     cy.findByRole('heading', { name: 'Browse our FAQ' }).should('be.visible')
     const toggleAccordion = (buttonName) => {
@@ -50,7 +68,7 @@ function cTrader_page() {
 
 describe('QATEST-23425 - should validate the cTrader page in responsive', () => {
 
-    it.only('should be able to navigate to cTrader page from home page and validate the page content and links in Mobile', () => {
+    it('should be able to navigate to cTrader page from home page and validate the page content and links in Mobile', () => {
         cy.c_visitResponsive(Cypress.env('RegionROW'))
         homeBanner.elements.hamBurgerMenu().should('be.visible').click()
         homeBanner.elements.tradeMenu().should('be.visible').click()
@@ -60,7 +78,7 @@ describe('QATEST-23425 - should validate the cTrader page in responsive', () => 
 })
 describe('QATEST-23425 - should validate the cTrader page in desktop', () => {
 
-    it.only('should be able to navigate to cTrader page from home page and validate the page content and links in Desktop', () => {
+    it('should be able to navigate to cTrader page from home page and validate the page content and links in Desktop', () => {
         cy.c_visitResponsive(Cypress.env('RegionROW'), 'desktop')
         homeBanner.elements.tradeMenu().should('be.visible').click()
         cy.findAllByText('Fast CFDs platform with inbuilt copy trading.').eq(0).should('be.visible').click()

--- a/cypress/e2e/full/tradingPlatformCtrader.cy.js
+++ b/cypress/e2e/full/tradingPlatformCtrader.cy.js
@@ -26,7 +26,7 @@ function cTrader_page() {
         cy.url().should(url => {
         expect(urlPath.some(path => url.includes(path))).to.be.true;
         });
-        cy.go('back'); 
+        cy.c_go('back'); 
     }
 
     cy.findByRole('heading', { name: 'Browse our FAQ' }).should('be.visible')
@@ -50,7 +50,7 @@ function cTrader_page() {
 
 describe('QATEST-23425 - should validate the cTrader page in responsive', () => {
 
-    it('should be able to navigate to cTrader page from home page and validate the page content and links in Mobile', () => {
+    it.only('should be able to navigate to cTrader page from home page and validate the page content and links in Mobile', () => {
         cy.c_visitResponsive(Cypress.env('RegionROW'))
         homeBanner.elements.hamBurgerMenu().should('be.visible').click()
         homeBanner.elements.tradeMenu().should('be.visible').click()
@@ -60,7 +60,7 @@ describe('QATEST-23425 - should validate the cTrader page in responsive', () => 
 })
 describe('QATEST-23425 - should validate the cTrader page in desktop', () => {
 
-    it('should be able to navigate to cTrader page from home page and validate the page content and links in Desktop', () => {
+    it.only('should be able to navigate to cTrader page from home page and validate the page content and links in Desktop', () => {
         cy.c_visitResponsive(Cypress.env('RegionROW'), 'desktop')
         homeBanner.elements.tradeMenu().should('be.visible').click()
         cy.findAllByText('Fast CFDs platform with inbuilt copy trading.').eq(0).should('be.visible').click()

--- a/cypress/e2e/full/tradingPlatformDbot.cy.js
+++ b/cypress/e2e/full/tradingPlatformDbot.cy.js
@@ -16,7 +16,7 @@ function Dbot_page()
     urlPaths.forEach(urlPath => {
         cy.contains(`a[href="${urlPath}"]`,'Learn more').click()
         cy.url().should('contain',urlPath)
-        cy.go('back')
+        cy.c_go('back')
     });
 
     cy.findByRole('heading', { name: 'Build your strategy visually' }, { timeout: 5000 }).should('be.visible')
@@ -27,14 +27,15 @@ function Dbot_page()
     {
         cy.findAllByText('Create free demo account', { timeout: 5000 }).eq(index).click();
         cy.url().should('include', '/signup/')
-        cy.go('back')
+        cy.c_go('back')
     }
 
     for (let index = 0; index < 2; index++) 
     {
         cy.findAllByRole('link', {name: 'Go to live demo'}, { timeout: 5000 }).eq(index).invoke('attr','target','_self').click()
-        cy.go('back')
+        cy.c_go('back')
     }
+
     cy.findByText('Build a trading robot in 5 easy steps').should('be.visible')
     cy.findByText('1. Select an asset').click()
     cy.findByText('2. Set the purchase conditions').click()

--- a/cypress/e2e/full/tradingPlatformDbot.cy.js
+++ b/cypress/e2e/full/tradingPlatformDbot.cy.js
@@ -10,16 +10,15 @@ function Dbot_page()
     cy.findByRole('img', { name: 'dbot logo' }).should('be.visible')
 
     cy.findByRole('heading', { name: 'Check out our other platforms' }).should('be.visible')
-    for (let index = 0; index < 4; index++) 
-    {
-        cy.findAllByText('Learn more' , {timeout: 10000}).eq(index).click()
-        const urlPath = ['/dmt5/', '/dtrader/', '/deriv-go/', '/derivx/'];
+    
+    const urlPaths = ['/dmt5/', '/dtrader/', '/deriv-go/', '/derivx/'];
 
-        cy.url().should(url => {
-        expect(urlPath.some(path => url.includes(path))).to.be.true;
-        });
-        cy.c_go('back'); 
-    }
+    urlPaths.forEach(urlPath => {
+        cy.contains(`a[href="${urlPath}"]`,'Learn more').click()
+        cy.url().should('contain',urlPath)
+        cy.go('back')
+    });
+
     cy.findByRole('heading', { name: 'Build your strategy visually' }, { timeout: 5000 }).should('be.visible')
     cy.findByRole('img', { name: 'Build your bot using drag and drop' }).click()
     cy.findByRole('heading', { name: 'Automate your trading ideas without writing code' }, { timeout: 10000 }).should('be.visible')
@@ -28,13 +27,13 @@ function Dbot_page()
     {
         cy.findAllByText('Create free demo account', { timeout: 5000 }).eq(index).click();
         cy.url().should('include', '/signup/')
-        cy.c_go('back')
+        cy.go('back')
     }
 
     for (let index = 0; index < 2; index++) 
     {
         cy.findAllByRole('link', {name: 'Go to live demo'}, { timeout: 5000 }).eq(index).invoke('attr','target','_self').click()
-        cy.c_go('back')
+        cy.go('back')
     }
     cy.findByText('Build a trading robot in 5 easy steps').should('be.visible')
     cy.findByText('1. Select an asset').click()
@@ -50,7 +49,7 @@ function Dbot_page()
 
 describe('QATEST-1548 - should validate the Dbot page in responsive', () => {
 
-    it.only('should be able to navigate to Dbot page from home page and validate the page content and links in Mobile', () => {
+    it('should be able to navigate to Dbot page from home page and validate the page content and links in Mobile', () => {
         cy.c_visitResponsive(Cypress.env('RegionROW'))
         homeBanner.elements.hamBurgerMenu().should('be.visible').click()
         homeBanner.elements.tradeMenu().should('be.visible').click()
@@ -60,7 +59,7 @@ describe('QATEST-1548 - should validate the Dbot page in responsive', () => {
 })
     describe('QATEST-1541 - should validate the Dbot page in desktop', () => {
 
-        it.only('should be able to navigate to Dbot page from home page and validate the page content and links in Desktop', () => {
+        it('should be able to navigate to Dbot page from home page and validate the page content and links in Desktop', () => {
             cy.c_visitResponsive(Cypress.env('RegionROW'), 'desktop')
             homeBanner.elements.tradeMenu().should('be.visible').click()
             cy.findAllByText('Deriv Bot').eq(0).should('be.visible').click()

--- a/cypress/e2e/full/tradingPlatformDbot.cy.js
+++ b/cypress/e2e/full/tradingPlatformDbot.cy.js
@@ -32,15 +32,9 @@ function Dbot_page()
             title:'Deriv X - a multi-asset CFD trading platform available on Deriv',
             content:'Get trading with Deriv X'
         }
-    ];
+    ]
 
-    urlDetails.forEach(details => {
-        cy.contains(`a[href="${details.url}"]`,'Learn more').click()
-        cy.title().should('equal', details.title)
-        cy.contains('h1',details.content)
-        cy.url().should('contain',details.url)
-        cy.c_go('back')
-    });
+    cy.c_checkAllPlatformLinks(urlDetails)
 
     cy.findByRole('heading', { name: 'Build your strategy visually' }, { timeout: 5000 }).should('be.visible')
     cy.findByRole('img', { name: 'Build your bot using drag and drop' }).click()

--- a/cypress/e2e/full/tradingPlatformDbot.cy.js
+++ b/cypress/e2e/full/tradingPlatformDbot.cy.js
@@ -18,24 +18,23 @@ function Dbot_page()
         cy.url().should(url => {
         expect(urlPath.some(path => url.includes(path))).to.be.true;
         });
-        cy.go('back'); 
+        cy.c_go('back'); 
     }
     cy.findByRole('heading', { name: 'Build your strategy visually' }, { timeout: 5000 }).should('be.visible')
     cy.findByRole('img', { name: 'Build your bot using drag and drop' }).click()
-
     cy.findByRole('heading', { name: 'Automate your trading ideas without writing code' }, { timeout: 10000 }).should('be.visible')
+
     for (let index = 0; index < 2; index++) 
     {
-        
         cy.findAllByText('Create free demo account', { timeout: 5000 }).eq(index).click();
         cy.url().should('include', '/signup/')
-        cy.go('back')
+        cy.c_go('back')
     }
+
     for (let index = 0; index < 2; index++) 
     {
-        
-        cy.findAllByRole('link', {name: 'Go to live demo'}, { timeout: 5000 }).eq(index).click()
-       
+        cy.findAllByRole('link', {name: 'Go to live demo'}, { timeout: 5000 }).eq(index).invoke('attr','target','_self').click()
+        cy.c_go('back')
     }
     cy.findByText('Build a trading robot in 5 easy steps').should('be.visible')
     cy.findByText('1. Select an asset').click()
@@ -51,7 +50,7 @@ function Dbot_page()
 
 describe('QATEST-1548 - should validate the Dbot page in responsive', () => {
 
-    it('should be able to navigate to Dbot page from home page and validate the page content and links in Mobile', () => {
+    it.only('should be able to navigate to Dbot page from home page and validate the page content and links in Mobile', () => {
         cy.c_visitResponsive(Cypress.env('RegionROW'))
         homeBanner.elements.hamBurgerMenu().should('be.visible').click()
         homeBanner.elements.tradeMenu().should('be.visible').click()
@@ -61,7 +60,7 @@ describe('QATEST-1548 - should validate the Dbot page in responsive', () => {
 })
     describe('QATEST-1541 - should validate the Dbot page in desktop', () => {
 
-        it('should be able to navigate to Dbot page from home page and validate the page content and links in Desktop', () => {
+        it.only('should be able to navigate to Dbot page from home page and validate the page content and links in Desktop', () => {
             cy.c_visitResponsive(Cypress.env('RegionROW'), 'desktop')
             homeBanner.elements.tradeMenu().should('be.visible').click()
             cy.findAllByText('Deriv Bot').eq(0).should('be.visible').click()

--- a/cypress/e2e/full/tradingPlatformDbot.cy.js
+++ b/cypress/e2e/full/tradingPlatformDbot.cy.js
@@ -11,19 +11,36 @@ function Dbot_page()
 
     cy.findByRole('heading', { name: 'Check out our other platforms' }).should('be.visible')
     
-    const urlPaths = ['/dmt5/', '/dtrader/', '/deriv-go/', '/derivx/'];
+    const urlDetails = [
+        {
+            url:'/dmt5/',
+            title:'Deriv MT5 | MetaTrader 5 trading platform | Deriv',
+            content:'Get trading with Deriv MT5',
+        }, 
+        {
+            url:'/dtrader/',
+            title:'DTrader | Online trading platform | Deriv',
+            content:'Get into the Deriv Trader experience',
+        }, 
+        {
+            url:'/deriv-go/',
+            title:'Trade forex, synthetics, and cryptocurrencies with our app — Deriv GO.',
+            content:'Get trading with Deriv GO',
+        }, 
+        {
+            url:'/derivx/', 
+            title:'Deriv X - a multi-asset CFD trading platform available on Deriv',
+            content:'Get trading with Deriv X'
+        }
+    ];
 
-    // urlPaths.forEach(urlPath => {
-    //     if(urlPath=='/derivx/'){
-    //         cy.contains('div[direction="column"]','Check out our other platforms').next('div').within(()=>{
-    //             cy.get('.next-arrow').click()
-    //         })
-    //     }
-    //     cy.contains(`a[href="${urlPath}"]`,'Learn more').click()
-    //     cy.c_waitForPageLoad()
-    //     cy.url().should('contain',urlPath)
-    //     cy.c_go('back')
-    // });
+    urlDetails.forEach(details => {
+        cy.contains(`a[href="${details.url}"]`,'Learn more').click()
+        cy.title().should('equal', details.title)
+        cy.contains('h1',details.content)
+        cy.url().should('contain',details.url)
+        cy.c_go('back')
+    });
 
     cy.findByRole('heading', { name: 'Build your strategy visually' }, { timeout: 5000 }).should('be.visible')
     cy.findByRole('img', { name: 'Build your bot using drag and drop' }).click()
@@ -66,7 +83,7 @@ describe('QATEST-1548 - should validate the Dbot page in responsive', () => {
 })
     describe('QATEST-1541 - should validate the Dbot page in desktop', () => {
 
-        it.only('should be able to navigate to Dbot page from home page and validate the page content and links in Desktop', () => {
+        it('should be able to navigate to Dbot page from home page and validate the page content and links in Desktop', () => {
             cy.c_visitResponsive(Cypress.env('RegionROW'), 'desktop')
             homeBanner.elements.tradeMenu().should('be.visible').click()
             cy.findAllByText('Deriv Bot').eq(0).should('be.visible').click()

--- a/cypress/e2e/full/tradingPlatformDbot.cy.js
+++ b/cypress/e2e/full/tradingPlatformDbot.cy.js
@@ -13,17 +13,17 @@ function Dbot_page()
     
     const urlPaths = ['/dmt5/', '/dtrader/', '/deriv-go/', '/derivx/'];
 
-    urlPaths.forEach(urlPath => {
-        if(urlPath=='/derivx/'){
-            cy.contains('div[direction="column"]','Check out our other platforms').next('div').within(()=>{
-                cy.get('.next-arrow').click()
-            })
-        }
-        cy.contains(`a[href="${urlPath}"]`,'Learn more').click()
-        cy.c_waitForPageLoad()
-        cy.url().should('contain',urlPath)
-        cy.c_go('back')
-    });
+    // urlPaths.forEach(urlPath => {
+    //     if(urlPath=='/derivx/'){
+    //         cy.contains('div[direction="column"]','Check out our other platforms').next('div').within(()=>{
+    //             cy.get('.next-arrow').click()
+    //         })
+    //     }
+    //     cy.contains(`a[href="${urlPath}"]`,'Learn more').click()
+    //     cy.c_waitForPageLoad()
+    //     cy.url().should('contain',urlPath)
+    //     cy.c_go('back')
+    // });
 
     cy.findByRole('heading', { name: 'Build your strategy visually' }, { timeout: 5000 }).should('be.visible')
     cy.findByRole('img', { name: 'Build your bot using drag and drop' }).click()

--- a/cypress/e2e/full/tradingPlatformDbot.cy.js
+++ b/cypress/e2e/full/tradingPlatformDbot.cy.js
@@ -50,6 +50,7 @@ function Dbot_page()
     {
         cy.findAllByText('Create free demo account', { timeout: 5000 }).eq(index).click();
         cy.url().should('include', '/signup/')
+        cy.get('input[id="email_address"]').should('exist')
         cy.c_go('back')
     }
 

--- a/cypress/e2e/full/tradingPlatformDbot.cy.js
+++ b/cypress/e2e/full/tradingPlatformDbot.cy.js
@@ -14,7 +14,13 @@ function Dbot_page()
     const urlPaths = ['/dmt5/', '/dtrader/', '/deriv-go/', '/derivx/'];
 
     urlPaths.forEach(urlPath => {
+        if(urlPath=='/derivx/'){
+            cy.contains('div[direction="column"]','Check out our other platforms').next('div').within(()=>{
+                cy.get('.next-arrow').click()
+            })
+        }
         cy.contains(`a[href="${urlPath}"]`,'Learn more').click()
+        cy.c_waitForPageLoad()
         cy.url().should('contain',urlPath)
         cy.c_go('back')
     });
@@ -60,7 +66,7 @@ describe('QATEST-1548 - should validate the Dbot page in responsive', () => {
 })
     describe('QATEST-1541 - should validate the Dbot page in desktop', () => {
 
-        it('should be able to navigate to Dbot page from home page and validate the page content and links in Desktop', () => {
+        it.only('should be able to navigate to Dbot page from home page and validate the page content and links in Desktop', () => {
             cy.c_visitResponsive(Cypress.env('RegionROW'), 'desktop')
             homeBanner.elements.tradeMenu().should('be.visible').click()
             cy.findAllByText('Deriv Bot').eq(0).should('be.visible').click()

--- a/cypress/e2e/full/tradingPlatformDtrader.cy.js
+++ b/cypress/e2e/full/tradingPlatformDtrader.cy.js
@@ -18,18 +18,32 @@ function validate_dtraderpage(region)
     cy.findAllByRole('listitem').contains('Place a trade').click();
     cy.findByRole('img', { name: 'Place a trade' }).scrollIntoView().should("be.visible", {timeout: 50000,})
 
+    
     if (region === 'ROW') {   
-    cy.findByRole('heading', { name: 'Check out our other platforms' }).should('be.visible')
-    for (let index = 0; index < 4; index++) 
-       {
-         cy.findAllByText('Learn more' , {timeout: 10000}).eq(index).click()
-         const urlPath = ['/dmt5/', '/deriv-go/', '/derivx/', '/dbot/'];
- 
-         cy.url().should(url => {
-         expect(urlPath.some(path => url.includes(path))).to.be.true;
-         });
-         cy.c_go('back'); 
-       }
+        const urlDetails = [
+            {
+                url:'/dmt5/',
+                title:'Deriv MT5 | MetaTrader 5 trading platform | Deriv',
+                content:'Get trading with Deriv MT5',
+            }, 
+            {
+                url:'/dbot/',
+                title:'DBot | Trading robot | Deriv',
+                content:'Get into the Deriv Bot experience',
+            }, 
+            {
+                url:'/deriv-go/',
+                title:'Trade forex, synthetics, and cryptocurrencies with our app — Deriv GO.',
+                content:'Get trading with Deriv GO',
+            }, 
+            {
+                url:'/derivx/', 
+                title:'Deriv X - a multi-asset CFD trading platform available on Deriv',
+                content:'Get trading with Deriv X'
+            }
+        ];
+        cy.findByRole('heading', { name: 'Check out our other platforms' }).should('be.visible')
+        cy.c_checkAllPlatformLinks(urlDetails)
     }
 
     for(let index= 0; index < 2; index++)
@@ -42,14 +56,14 @@ function validate_dtraderpage(region)
 
 describe('QATEST-1529 - should validate the dtrader page in desktop', () => {
 
-    it.only('should be able to navigate to dtrader page from home page and validate the page content and links for EU', () => {
+    it('should be able to navigate to dtrader page from home page and validate the page content and links for EU', () => {
         cy.c_visitResponsive(Cypress.env('RegionEU'), 'desktop')
         homeBanner.elements.tradeMenu().should('be.visible').click()
         cy.findAllByText('Deriv Trader').eq(0).should('be.visible').click();
         validate_dtraderpage('EU')
     })
 
-    it.only('should be able to navigate to dtrader page from home page and validate the page content and links for ROW', () => {
+    it('should be able to navigate to dtrader page from home page and validate the page content and links for ROW', () => {
         cy.c_visitResponsive(Cypress.env('RegionROW'), 'desktop')
         homeBanner.elements.tradeMenu().should('be.visible').click()
         cy.findAllByText('Deriv Trader').eq(0).should('be.visible').click();
@@ -58,7 +72,7 @@ describe('QATEST-1529 - should validate the dtrader page in desktop', () => {
 
 })
 
-describe.only('QATEST-1536 - should validate the dtrader page in responsive', () => {
+describe('QATEST-1536 - should validate the dtrader page in responsive', () => {
     
     it('should be able to navigate to dtrader page from home page and validate the page content and links for EU', () => {
         cy.c_visitResponsive(Cypress.env('RegionEU'))

--- a/cypress/e2e/full/tradingPlatformDtrader.cy.js
+++ b/cypress/e2e/full/tradingPlatformDtrader.cy.js
@@ -28,27 +28,28 @@ function validate_dtraderpage(region)
          cy.url().should(url => {
          expect(urlPath.some(path => url.includes(path))).to.be.true;
          });
-         cy.go('back'); 
+         cy.c_go('back'); 
        }
     }
 
     for(let index= 0; index < 2; index++)
     {
-        cy.findAllByRole('link', { name: 'Go to live demo' },{timeout: 10000}).eq(index).click()
+        cy.findAllByRole('link', { name: 'Go to live demo' },{timeout: 10000}).eq(index).invoke('attr','target','_self').click()
+        cy.c_go('back')
     }
     cy.contains('Create free demo account').eq(0).click()
 }
 
 describe('QATEST-1529 - should validate the dtrader page in desktop', () => {
 
-    it('should be able to navigate to dtrader page from home page and validate the page content and links for EU', () => {
+    it.only('should be able to navigate to dtrader page from home page and validate the page content and links for EU', () => {
         cy.c_visitResponsive(Cypress.env('RegionEU'), 'desktop')
         homeBanner.elements.tradeMenu().should('be.visible').click()
         cy.findAllByText('Deriv Trader').eq(0).should('be.visible').click();
         validate_dtraderpage('EU')
     })
 
-    it('should be able to navigate to dtrader page from home page and validate the page content and links for ROW', () => {
+    it.only('should be able to navigate to dtrader page from home page and validate the page content and links for ROW', () => {
         cy.c_visitResponsive(Cypress.env('RegionROW'), 'desktop')
         homeBanner.elements.tradeMenu().should('be.visible').click()
         cy.findAllByText('Deriv Trader').eq(0).should('be.visible').click();
@@ -57,7 +58,7 @@ describe('QATEST-1529 - should validate the dtrader page in desktop', () => {
 
 })
 
-describe('QATEST-1536 - should validate the dtrader page in responsive', () => {
+describe.only('QATEST-1536 - should validate the dtrader page in responsive', () => {
     
     it('should be able to navigate to dtrader page from home page and validate the page content and links for EU', () => {
         cy.c_visitResponsive(Cypress.env('RegionEU'))

--- a/cypress/e2e/full/tradingPlatformMT5.cy.js
+++ b/cypress/e2e/full/tradingPlatformMT5.cy.js
@@ -119,19 +119,33 @@ function validate_dmt5page(region)
     cy.go('back')
 
     if (region === 'ROW') {   
-    cy.findByRole('heading', { name: 'Check out our other platforms' }).should('be.visible')
-    for (let index = 0; index < 4; index++) 
-       {
-        cy.findAllByText('Learn more' , {timeout: 10000}).eq(index).click()
-        const urlPath = ['/dtrader/', '/deriv-go/', '/derivx/', '/dbot/'];
-
-        cy.url().should(url => {
-        expect(urlPath.some(path => url.includes(path))).to.be.true;
-        });
-        cy.c_go('back'); 
-       }
+      cy.findByRole('heading', { name: 'Check out our other platforms' }).should('be.visible')
+      const urlDetails = [
+        {
+          url:'/dbot/',
+          title:'DBot | Trading robot | Deriv',
+          content:'Get into the Deriv Bot experience',
+        }, 
+        {
+            url:'/dtrader/',
+            title:'DTrader | Online trading platform | Deriv',
+            content:'Get into the Deriv Trader experience',
+        }, 
+        {
+            url:'/deriv-go/',
+            title:'Trade forex, synthetics, and cryptocurrencies with our app — Deriv GO.',
+            content:'Get trading with Deriv GO',
+        }, 
+        {
+            url:'/derivx/', 
+            title:'Deriv X - a multi-asset CFD trading platform available on Deriv',
+            content:'Get trading with Deriv X'
+        }
+      ]
+      cy.c_checkAllPlatformLinks(urlDetails)
     }
     cy.findByRole('link', { name: 'Deriv demo account' }).click()
+    cy.get('input[id="email_address"]').should('exist')
     cy.findByText('Join over 2.5 million traders').should('be.visible')
     cy.go('back')
     
@@ -157,7 +171,7 @@ describe('QATEST-1553 - should validate the dmt5 page in desktop', () => {
 
 describe('QATEST-1563 - should validate the dmt5 page in responsive', () => {
     
-    it.only('should be able to navigate to dmt5 page from home page and validate the page content and links for EU', () => {
+    it('should be able to navigate to dmt5 page from home page and validate the page content and links for EU', () => {
         cy.c_visitResponsive(Cypress.env('RegionEU'))
         homeBanner.elements.hamBurgerMenu().should('be.visible').click()
         homeBanner.elements.tradeMenu().should('be.visible').click()
@@ -165,7 +179,7 @@ describe('QATEST-1563 - should validate the dmt5 page in responsive', () => {
         validate_dmt5page('EU')
     })
 
-    it.only('should be able to navigate to dmt5 page from home page and validate the page content and links for ROW', () => {
+    it('should be able to navigate to dmt5 page from home page and validate the page content and links for ROW', () => {
         cy.c_visitResponsive(Cypress.env('RegionROW'))
         homeBanner.elements.hamBurgerMenu().should('be.visible').click()
         homeBanner.elements.tradeMenu().should('be.visible').click()

--- a/cypress/e2e/full/tradingPlatformMT5.cy.js
+++ b/cypress/e2e/full/tradingPlatformMT5.cy.js
@@ -128,7 +128,7 @@ function validate_dmt5page(region)
         cy.url().should(url => {
         expect(urlPath.some(path => url.includes(path))).to.be.true;
         });
-        cy.go('back'); 
+        cy.c_go('back'); 
        }
     }
     cy.findByRole('link', { name: 'Deriv demo account' }).click()
@@ -157,7 +157,7 @@ describe('QATEST-1553 - should validate the dmt5 page in desktop', () => {
 
 describe('QATEST-1563 - should validate the dmt5 page in responsive', () => {
     
-    it('should be able to navigate to dmt5 page from home page and validate the page content and links for EU', () => {
+    it.only('should be able to navigate to dmt5 page from home page and validate the page content and links for EU', () => {
         cy.c_visitResponsive(Cypress.env('RegionEU'))
         homeBanner.elements.hamBurgerMenu().should('be.visible').click()
         homeBanner.elements.tradeMenu().should('be.visible').click()
@@ -165,7 +165,7 @@ describe('QATEST-1563 - should validate the dmt5 page in responsive', () => {
         validate_dmt5page('EU')
     })
 
-    it('should be able to navigate to dmt5 page from home page and validate the page content and links for ROW', () => {
+    it.only('should be able to navigate to dmt5 page from home page and validate the page content and links for ROW', () => {
         cy.c_visitResponsive(Cypress.env('RegionROW'))
         homeBanner.elements.hamBurgerMenu().should('be.visible').click()
         homeBanner.elements.tradeMenu().should('be.visible').click()

--- a/cypress/support/POM/commonPage.js
+++ b/cypress/support/POM/commonPage.js
@@ -23,8 +23,6 @@ class footer {
         .findByText('You are being redirected to an external website.'),
     cfdFloatingBannerLink: () =>
       cy.contains('% of retail investor accounts lose money when trading CFDs with Deriv, read our full Risk disclosure here'),
-    whatsappIcon: () =>
-    cy.findByRole("button", { name: "whatsapp icon" }),
   }
 
   riskDisclosurePdf = {
@@ -65,7 +63,7 @@ class footer {
     })
     this.elements.proceedButton().click()
     cy.reload()
-    this.elements.whatsappIcon().should("be.visible", {timeout: 30000});
+    cy.c_waitForPageLoad()
     cy.get('@windowOpen').should('be.calledWith', socialWebsiteUrl)
   }
 }

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -11,7 +11,7 @@ Cypress.on('uncaught:exception', (err, runnable) => {
 
 
 Cypress.Commands.add('c_waitForPageLoad',()=>{
-  cy.findByRole("button", { name: "whatsapp icon" ,timeout:30000 }).should("be.visible", {timeout: 30000,})
+  cy.findByRole("button", { name: "whatsapp icon" ,timeout:30000 }).should("be.visible")
 })
 
 Cypress.Commands.add("c_visitResponsive", (path, size, quickLoad ) => {
@@ -76,6 +76,16 @@ Cypress.Commands.add('c_emailVerification', (verification_code, event_email_url,
         })
     }
   )
+})
+
+Cypress.Commands.add('c_checkAllPlatformLinks',(urlDetails)=>{
+  urlDetails.forEach(details => {
+    cy.contains(`a[href="${details.url}"]`,'Learn more').click()
+    cy.title().should('equal', details.title)
+    cy.contains('h1',details.content)
+    cy.url().should('contain',details.url)
+    cy.c_go('back')
+  })
 })
 
 

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -38,6 +38,16 @@ Cypress.Commands.add("c_visitResponsive", (path, size, quickLoad ) => {
 }
 });
 
+
+Cypress.Commands.add('c_go',(direction ,quickLoad)=>{
+  cy.go(direction)
+  if(quickLoad===undefined){
+    cy.findByRole("button", { name: "whatsapp icon" }).should("be.visible", {
+      timeout: 30000,
+    })
+  }
+})
+
 Cypress.Commands.add('c_generateRandomEmail', (domain) => {
   return `user${Math.floor(Math.random() * 100000)}${domain}`
 })

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -11,7 +11,7 @@ Cypress.on('uncaught:exception', (err, runnable) => {
 
 
 Cypress.Commands.add('c_waitForPageLoad',()=>{
-  cy.get('button[name="whatsapp icon"]',{timeout:30000}).should("be.visible")
+  cy.get('img[alt="whatsapp icon"]',{timeout:30000}).should("be.visible")
 })
 
 Cypress.Commands.add("c_visitResponsive", (path, size, quickLoad ) => {

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -11,7 +11,7 @@ Cypress.on('uncaught:exception', (err, runnable) => {
 
 
 Cypress.Commands.add('c_waitForPageLoad',()=>{
-  cy.findByRole("button", { name: "whatsapp icon" }).should("be.visible", {timeout: 30000,})
+  cy.get('button[name="whatsapp icon"]',{timeout:30000}).should("be.visible")
 })
 
 Cypress.Commands.add("c_visitResponsive", (path, size, quickLoad ) => {

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -9,6 +9,11 @@ Cypress.on('uncaught:exception', (err, runnable) => {
   return false
 })
 
+
+Cypress.Commands.add('c_waitForPageLoad',()=>{
+  cy.findByRole("button", { name: "whatsapp icon" }).should("be.visible", {timeout: 30000,})
+})
+
 Cypress.Commands.add("c_visitResponsive", (path, size, quickLoad ) => {
   //Custom command that allows us to use baseUrl + path and detect with this is a responsive run or not.
   cy.log(path);
@@ -23,9 +28,7 @@ Cypress.Commands.add("c_visitResponsive", (path, size, quickLoad ) => {
   if (path.includes("region")) {
     //Wait for relevent elements to appear (based on page)
     cy.log("Home page Selected");
-    cy.findByRole("button", { name: "whatsapp icon" }).should("be.visible", {
-      timeout: 30000,
-    }); //For the home page, this seems to be the best indicator that a page has fully loaded. It may change in the future.
+    cy.c_waitForPageLoad() //For the home page, this seems to be the best indicator that a page has fully loaded. It may change in the future.
   }
 
   if (path.includes("help-centre")) {
@@ -38,13 +41,10 @@ Cypress.Commands.add("c_visitResponsive", (path, size, quickLoad ) => {
 }
 });
 
-
 Cypress.Commands.add('c_go',(direction ,quickLoad)=>{
   cy.go(direction)
   if(quickLoad===undefined){
-    cy.findByRole("button", { name: "whatsapp icon" }).should("be.visible", {
-      timeout: 30000,
-    })
+    cy.c_waitForPageLoad()
   }
 })
 

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -11,7 +11,7 @@ Cypress.on('uncaught:exception', (err, runnable) => {
 
 
 Cypress.Commands.add('c_waitForPageLoad',()=>{
-  cy.get('img[alt="whatsapp icon"]',{timeout:30000}).should("be.visible")
+  cy.findByRole("button", { name: "whatsapp icon" ,timeout:30000 }).should("be.visible", {timeout: 30000,})
 })
 
 Cypress.Commands.add("c_visitResponsive", (path, size, quickLoad ) => {


### PR DESCRIPTION
Updated code to make sure that page for each platform is visited. Previously we were only verifying the url of the next page due to this our test never visited the next platform page properly because of this when the command cy.go('back') was executed the test would be redirected to the homepage where it was unable to find the element.

made new custom commands:
- c_go() which will wait for the complete page to load befor executing the next step 
- c_waitForPageLoad() and moved the wait for whatsapp icon in to that to remove duplication.
- c_checkAllPlatforms() which will iterate through each platform available on page based on the array of objects provided for the links.

One test for responsive (QATEST-23425 - should validate the cTrader page in responsive) will keep on failing because of a UI issue which needs to fixed by frontend. Due to this issue another Pagination element covers the learn more button. The CU Card fro this ticket is [card](https://app.clickup.com/t/20696747/DPROD-3530) 

The workflow after these changes is [workflow](https://github.com/deriv-com/e2e-deriv-com/actions/runs/7926499311)

