### PR TITLE
Remove Labuan image test

### DIFF
--- a/cypress/e2e/smoke/rowRegulatory.cy.js
+++ b/cypress/e2e/smoke/rowRegulatory.cy.js
@@ -3,8 +3,7 @@ import '@testing-library/cypress/add-commands'
 function checkRegulatorySection()
 {
     cy.findByRole('heading', { name: 'Deriv Investments (Europe) Limited' }).should('be.visible')
-    cy.findByRole('heading', { name: 'Deriv (FX) Ltd' }).should('be.visible')
-    cy.findByRole('img', { name: 'Labuan Fintech Association' }).should('be.visible')
+    cy.findByRole("heading", { name: "Deriv (FX) Ltd" }).should("be.visible")
     cy.findByRole('heading', { name: 'Deriv (BVI) Ltd' }).should('be.visible')
     cy.findByRole('img', { name: 'British Virgin Islands Financial Services Commission' }).should('be.visible')
     cy.findByRole('heading', { name: 'Deriv (V) Ltd' }).should('be.visible')
@@ -14,16 +13,19 @@ function checkRegulatorySection()
     cy.findByRole('img', { name: 'Deriv SVG' }).should('be.visible')
     cy.findByRole('heading', { name: 'Deriv.com Limited' }).should('be.visible')
     cy.findByRole('img', { name: 'Deriv Limited' }).should('be.visible')
-    cy.findByRole('heading', { name: 'The Financial Commission' }).should('be.visible') 
-    cy.findByRole('img', { name: 'The Financial Commission' }).should('be.visible') 
+    cy.findByRole("heading", { name: "The Financial Commission" }).should(
+      "be.visible"
+    )
+    cy.findByRole("img", { name: "The Financial Commission" }).should(
+      "be.visible"
+    )
 }
 
 function checkViewLicenseLink()
-{   
-    for(let index= 0; index < 4; index++)
-    {
-        cy.findAllByRole('link', { name: '(view licence)' }).eq(index).click()
-    }
+{
+  for (let index = 0; index < 4; index++) {
+    cy.findAllByRole("link", { name: "(view licence)" }).eq(index).click()
+  }
 }
 
 describe('QATEST-1644 - Regulatory page', () => {


### PR DESCRIPTION
Removing this test as we no longer use an image in the new revamped regulatory page.